### PR TITLE
A complete bug fix to crafting system

### DIFF
--- a/Assets/Resources/Data/Items/Materials/leaves.asset
+++ b/Assets/Resources/Data/Items/Materials/leaves.asset
@@ -25,8 +25,8 @@ MonoBehaviour:
   Subtype: 0
   Weight: 0
   StackSize: 999
-  IsFuel: 0
-  FuelDuration: 5
+  IsFuel: 1
+  FuelDuration: 3
   IsMaterial: 0
   IsCraftable: 0
   Recipes: []

--- a/Assets/Resources/Data/Items/coal.asset
+++ b/Assets/Resources/Data/Items/coal.asset
@@ -27,8 +27,8 @@ MonoBehaviour:
   Subtype: 0
   Weight: 0
   StackSize: 999
-  IsFuel: 0
-  FuelDuration: 0
+  IsFuel: 1
+  FuelDuration: 60
   IsMaterial: 1
   IsCraftable: 1
   Recipes: []

--- a/Assets/Scripts/UI/Crafting/FuelCraftingGUI.cs
+++ b/Assets/Scripts/UI/Crafting/FuelCraftingGUI.cs
@@ -18,6 +18,7 @@ public class FuelCraftingGUI : CraftingGUI
     public ItemSlotUI fuelSlot;
     public FuelBar fuelBar;
 
+    FuelBasedCrafting FuelBasedCrafterInstance;
     protected void CreateFuelSlotUI()
     {
 
@@ -28,19 +29,20 @@ public class FuelCraftingGUI : CraftingGUI
     {
         this.workstation = workstation;
 
-        var fbc = (FuelBasedCrafting)workstation.Crafter;
-        fbc.FuelContainer = new(1);
+        FuelBasedCrafterInstance = (FuelBasedCrafting)workstation.Crafter;
+        FuelBasedCrafterInstance.FuelContainer = new(1);
+        
 
-        fbc.OnFuelUpdate += OnFuelUpdate;
-        fbc.OnFuelReload += OnFuelReload;
-        fuelBar.fuelBasedCraftingInstance = fbc;
+        FuelBasedCrafterInstance.OnFuelUpdate += OnFuelUpdate;
+        FuelBasedCrafterInstance.OnFuelReload += OnFuelReload;
+        fuelBar.fuelBasedCraftingInstance = FuelBasedCrafterInstance;
         fuelBar.Value = 0;
         
 
         CreateOutputSlotUIs(workstation.WorkstationData.OutputSize);
         CreateQueueSlotUIs(workstation.WorkstationData.QueueSize);
 
-        fuelSlot.Link(fbc.FuelContainer.Slots[0]);
+        fuelSlot.Link(FuelBasedCrafterInstance.FuelContainer.Slots[0]);
         fuelSlot.OnMouseDown += OnFuelSlotClick;
     }
 
@@ -61,7 +63,7 @@ public class FuelCraftingGUI : CraftingGUI
             if (player.InventoryGUI.IsHoldingItem)
             {
                 var heldItem = player.InventoryGUI.HeldItem;
-                var fbc = (FuelBasedCrafting)workstation.Crafter;
+                var FuelBasedCrafterInstance = (FuelBasedCrafting)workstation.Crafter;
 
                 if (slot.IsEmpty || slot.Item.CompareTo(heldItem))
                 {
@@ -74,13 +76,13 @@ public class FuelCraftingGUI : CraftingGUI
                     {
                         //if there is a routine still ongoing, ignite fuel
                         //how tho...
-                        if (fbc.Routines.Count > 0 && !fbc.IsFuelRemainingAvailable())
+                        if (FuelBasedCrafterInstance.Routines.Count > 0 && !FuelBasedCrafterInstance.IsFuelRemainingAvailable())
                         {
-                            if (fbc.TryConsumeFuel())
+                            if (FuelBasedCrafterInstance.TryConsumeFuel())
                             {
-                                fbc.StartBurn();
+                                FuelBasedCrafterInstance.StartBurn();
                             }
-                            fbc.ContinueRemainingCraft();
+                            FuelBasedCrafterInstance.ContinueRemainingCraft();
                         }
                     }
                 }
@@ -104,7 +106,6 @@ public class FuelCraftingGUI : CraftingGUI
             if (player.InventoryGUI.IsHoldingItem)
             {
                 var heldItem = player.InventoryGUI.HeldItem;
-                var fbc = (FuelBasedCrafting)workstation.Crafter;
 
                 if (slot.IsEmpty || slot.Item.CompareTo(heldItem))
                 {
@@ -117,13 +118,13 @@ public class FuelCraftingGUI : CraftingGUI
                     {
                         //if there is a routine still ongoing, ignite fuel
                         //how tho...
-                        if (fbc.Routines.Count > 0 && !fbc.IsFuelRemainingAvailable())
+                        if (FuelBasedCrafterInstance.Routines.Count > 0 && !FuelBasedCrafterInstance.IsFuelRemainingAvailable())
                         {
-                            if (fbc.TryConsumeFuel())
+                            if (FuelBasedCrafterInstance.TryConsumeFuel())
                             {
-                                fbc.StartBurn();
+                                FuelBasedCrafterInstance.StartBurn();
                             }
-                            fbc.ContinueRemainingCraft();
+                            FuelBasedCrafterInstance.ContinueRemainingCraft();
                         }
                     }
                 }

--- a/Assets/Scripts/UI/Crafting/FuelCraftingGUI.cs
+++ b/Assets/Scripts/UI/Crafting/FuelCraftingGUI.cs
@@ -62,8 +62,13 @@ public class FuelCraftingGUI : CraftingGUI
 
             if (player.InventoryGUI.IsHoldingItem)
             {
+                if(!player.InventoryGUI.HeldItem.Data.IsFuel)
+                {
+                    print("You cannot put a non-fuel Item in the fuel slot");
+                    return;
+                }
+
                 var heldItem = player.InventoryGUI.HeldItem;
-                var FuelBasedCrafterInstance = (FuelBasedCrafting)workstation.Crafter;
 
                 if (slot.IsEmpty || slot.Item.CompareTo(heldItem))
                 {
@@ -105,6 +110,12 @@ public class FuelCraftingGUI : CraftingGUI
         {
             if (player.InventoryGUI.IsHoldingItem)
             {
+                if(!player.InventoryGUI.HeldItem.Data.IsFuel)
+                {
+                    print("You cannot put a non-fuel Item in the fuel slot");
+                    return;
+                }
+                
                 var heldItem = player.InventoryGUI.HeldItem;
 
                 if (slot.IsEmpty || slot.Item.CompareTo(heldItem))


### PR DESCRIPTION
+ Items not labeled as fuel can no longer be placed and consumed in the fuel slot
+ The number of fuel items to be placed in the fuel slot can be manually placed using right click (1 fuel item for each right click)
+ some minor optimizations